### PR TITLE
feat: updated molstar viewer

### DIFF
--- a/app/src/calculation.py
+++ b/app/src/calculation.py
@@ -145,21 +145,21 @@ class Calculation:
         structure.assign_label_seq_id()
         block = structure.make_mmcif_block()
         block.find_mmcif_category('_chem_comp.').erase() # remove pesky _chem_comp category >:(
-        partial_atomic_charges_meta_prefix = "_partial_atomic_charges_meta."
-        partial_atomic_charges_meta_attributes = ["id",
+        sb_ncbr_partial_atomic_charges_meta_prefix = "_sb_ncbr_partial_atomic_charges_meta."
+        sb_ncbr_partial_atomic_charges_meta_attributes = ["id",
                                                   "type",
                                                   "method"]
-        metadata_loop = block.init_loop(partial_atomic_charges_meta_prefix,
-                                        partial_atomic_charges_meta_attributes)
+        metadata_loop = block.init_loop(sb_ncbr_partial_atomic_charges_meta_prefix,
+                                        sb_ncbr_partial_atomic_charges_meta_attributes)
         metadata_loop.add_row(['1',
                                "'empirical'",
                                "'SQE+qp/Schindler 2021 (PUB_pept)'"])
-        partial_atomic_charges_prefix = "_partial_atomic_charges."
-        partial_atomic_charges_attributes = ["type_id",
+        sb_ncbr_partial_atomic_charges_prefix = "_sb_ncbr_partial_atomic_charges."
+        sb_ncbr_partial_atomic_charges_attributes = ["type_id",
                                              "atom_id",
                                              "charge"]
-        charges_loop = block.init_loop(partial_atomic_charges_prefix,
-                                       partial_atomic_charges_attributes)
+        charges_loop = block.init_loop(sb_ncbr_partial_atomic_charges_prefix,
+                                       sb_ncbr_partial_atomic_charges_attributes)
         for atomId, charge in enumerate(self.charges):
             charges_loop.add_row(["1",
                                   f"{atomId + 1}",

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -3,7 +3,7 @@
 {% block title %} αCharges – Calculation results {% endblock title %}
 
 {% block styles %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.2.0/dist/style.css">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 {% endblock styles %}
 
@@ -112,7 +112,7 @@
 </div>
 {% endblock body %}
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/molstar.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.2.0/dist/molstar.umd.js"></script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 <script>
     const structure_url = '{{ url_for("get_structure", ID=ID, FORMAT="cif") }}';

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -3,7 +3,7 @@
 {% block title %} αCharges – Calculation results {% endblock title %}
 
 {% block styles %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@0.0.10/dist/style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/style.css">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 {% endblock styles %}
 
@@ -82,16 +82,17 @@
                         <label class="form-check-label" for="colors_absolute">Charges (absolute)</label>
                     </div>
                     <div class="form-group form-inline mb-0">
-                        <label class="col-sm-6 col-lg-3 col-form-label" for="max_value">Max value:</label>
-                        <input class="col-sm-6 col-lg-3 form-control" type="number" id="max_value" name="max_value"
-                            min="0" max="5" step="0.1" value="0" disabled>
+                        <label class="col-auto col-form-label pl-0 pr-3" for="max_value">Max value:</label>
+                        <input class="col-3 form-control" type="number" id="max_value" name="max_value" min="0" max="5"
+                            step="0.1" value="0" disabled>
+                        <a class="btn btn-secondary text-sm text-white" id="reset_max_charge">Reset</a>
                     </div>
                 </div>
             </fieldset>
         </div>
     </div>
     <hr>
-    <div class="row">
+    <div class="row px-3">
         <div class="col">
             <div id="root"></div>
         </div>
@@ -111,7 +112,7 @@
 </div>
 {% endblock body %}
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@0.0.10/dist/molstar.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/molstar.umd.js"></script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 <script>
     const structure_url = '{{ url_for("get_structure", ID=ID, FORMAT="cif") }}';

--- a/app/templates/wrong_structure.html
+++ b/app/templates/wrong_structure.html
@@ -2,7 +2,7 @@
 
 {% block styles %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@0.0.11/dist/style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/style.css">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 {% endblock styles %}
 
@@ -34,7 +34,7 @@
             {% include 'base/flash.html' %}
         </div>
     </div>
-    <div class="row">
+    <div class="row px-3">
         <div class="col">
             <div id="root"></div>
         </div>
@@ -60,7 +60,7 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.3/dist/jquery.min.js"></script>
 <script src="{{ url_for('static', filename='bootstrap/bootstrap.bundle.min.js') }}"></script>
-<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@0.0.11/dist/molstar.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/molstar.umd.js"></script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 <script>
     const structure_url = '{{ url_for("get_structure", ID=ID, FORMAT="pdb") }}';

--- a/app/templates/wrong_structure.html
+++ b/app/templates/wrong_structure.html
@@ -2,7 +2,7 @@
 
 {% block styles %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.2.0/dist/style.css">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 {% endblock styles %}
 
@@ -60,7 +60,7 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.3/dist/jquery.min.js"></script>
 <script src="{{ url_for('static', filename='bootstrap/bootstrap.bundle.min.js') }}"></script>
-<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.1.5/dist/molstar.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/molstar-partial-charges@1.2.0/dist/molstar.umd.js"></script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 <script>
     const structure_url = '{{ url_for("get_structure", ID=ID, FORMAT="pdb") }}';


### PR DESCRIPTION
**Changes**:

- updated Molstar to latest version
- added reset button to absolute charge range
- updated mmCIF category names (added `_sb_ncbr` prefix)
- fixed residue coloring (some residues were colored the same even though their charges were off by more than 0.1 -> this was caused by reusing a consumed iterator) 